### PR TITLE
Make the shell script POSIX-compliant

### DIFF
--- a/$.sh
+++ b/$.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 VERSION=2
 
-if [[ $@ < 2 ]]
-then
+if [ -z "$1" ]; then
 	echo "$ version ${VERSION}"
-	echo ""
-	echo "Usage: $ COMMAND [ARGS..]"
+	echo
+	echo "Usage: $ COMMAND [ARGS...]"
+
+	# printf "$ version %s\n\nUsage: $ COMMAND [ARGS...]\n" "$VERSION"
 else
 	exec "$@"
 fi

--- a/$.sh
+++ b/$.sh
@@ -4,7 +4,7 @@ VERSION=2
 if [ -z "$1" ]; then
 	echo "$ version ${VERSION}"
 	echo
-	echo "Usage: $ COMMAND [ARGS...]"
+	echo "Usage: $ COMMAND [ARGS..]"
 
 	# printf "$ version %s\n\nUsage: $ COMMAND [ARGS...]\n" "$VERSION"
 else


### PR DESCRIPTION
The script `$.sh` specifies that it is POSIX-compliant (`#!/bin/sh`), however, it is not. Specifically, it uses Bash's double brackets.  
This PR simply modifies the script to only use POSIX-compliant shell scripting.

I do not know if this warrants a minor or a major version upgrade (I believe it should be a minor update), so I did not increment the version in any way.